### PR TITLE
derive: bump syn dependency to 2

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,5 +18,5 @@ A procmacro attribute to run your test in an isolated environment
 proc-macro = true
 
 [dependencies]
-syn = {version = "1.0.82", features = ["full", "extra-traits"] }
+syn = {version = "2", features = ["full", "extra-traits"] }
 quote = "1.0.10"


### PR DESCRIPTION
syn v1 is obsolete, update to v2. I've verified the tests are still passing with this.