### PR TITLE
Fix cmd_lib tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ mod tests {
     fn a_dummy_test_with_git() {
         let current_dir = std::env::current_dir().unwrap();
         run_cmd! (
-            info "Initializing test repo in $current_dir";
+            info "Initializing test repo in ${current_dir:?}";
             git init;
             git commit -m c1 --allow-empty;
             git commit -m c2 --allow-empty;
@@ -190,7 +190,7 @@ mod tests {
     fn another_dummy_test_with_git() {
         let current_dir = std::env::current_dir().unwrap();
         run_cmd! (
-            info "Initializing test repo in $current_dir";
+            info "Initializing test repo in ${current_dir:?}";
             git init;
             git commit -m "a commit" --allow-empty;
             git checkout -b branch1;
@@ -205,7 +205,7 @@ mod tests {
     fn a_dummy_test_with_return_type() -> Result<&'static str, &'static str> {
         let current_dir = std::env::current_dir().unwrap();
         run_cmd! (
-            info "Initializing test repo in $current_dir";
+            info "Initializing test repo in ${current_dir:?}";
             git init;
             git commit -m "a commit" --allow-empty;
             git checkout -b branch1;


### PR DESCRIPTION
See https://github.com/rust-shell-script/rust_cmd_lib/issues/75.

Before this PR:

```
$ cargo test
[…]
error[E0277]: `PathBuf` doesn't implement `std::fmt::Display`
   --> src/lib.rs:207:9
    |
207 | /         run_cmd! (
208 | |             info "Initializing test repo in $current_dir";
209 | |             git init;
210 | |             git commit -m "a commit" --allow-empty;
211 | |             git checkout -b branch1;
212 | |             git shortlog;
213 | |         )
    | |_________^ `PathBuf` cannot be formatted with the default formatter; call `.display()` on it
    |
    = help: the trait `std::fmt::Display` is not implemented for `PathBuf`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
    = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `run_cmd` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `sealed_test` (lib test) due to 3 previous errors
````

After this PR:

```
$ cargo test
[…]
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
[…]
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
```