### PR TITLE
Update cmd_lib dev-dependency to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ fs_extra = "1.2.0"
 sealed_test_derive = "1.1.0"
 
 [dev-dependencies]
-cmd_lib = "1.3.0"
+cmd_lib = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ mod tests {
     fn a_dummy_test_with_git() {
         let current_dir = std::env::current_dir().unwrap();
         run_cmd! (
-            info "Initializing test repo in $current_dir";
+            info "Initializing test repo in ${current_dir:?}";
             git init;
             git commit -m c1 --allow-empty;
             git commit -m c2 --allow-empty;
@@ -190,7 +190,7 @@ mod tests {
     fn another_dummy_test_with_git() {
         let current_dir = std::env::current_dir().unwrap();
         run_cmd! (
-            info "Initializing test repo in $current_dir";
+            info "Initializing test repo in ${current_dir:?}";
             git init;
             git commit -m "a commit" --allow-empty;
             git checkout -b branch1;
@@ -205,7 +205,7 @@ mod tests {
     fn a_dummy_test_with_return_type() -> Result<&'static str, &'static str> {
         let current_dir = std::env::current_dir().unwrap();
         run_cmd! (
-            info "Initializing test repo in $current_dir";
+            info "Initializing test repo in ${current_dir:?}";
             git init;
             git commit -m "a commit" --allow-empty;
             git checkout -b branch1;


### PR DESCRIPTION
This includes (applies on top of) https://github.com/oknozor/sealed-test/pull/8.